### PR TITLE
AC-914 : Open Grafana dashboard button added

### DIFF
--- a/.env
+++ b/.env
@@ -17,3 +17,4 @@ VUE_APP_KEYCLOAK_CLIENT_ID=aide-app
 VUE_APP_KEYCLOAK_ON_LOAD=login-required
 VUE_APP_AUTH_ENABLED=true
 VUE_APP_WORKFLOW_SPEC_URL=https://github.com/Project-MONAI/monai-deploy-workflow-manager/blob/main/guidelines/mwm-workflow-spec.md
+VUE_APP_GRAFANA_DASHBOARD_URL=https://sit-aide.answerdigital.io:2632

--- a/src/components/AdminHealthDashboard/IssuesTable.vue
+++ b/src/components/AdminHealthDashboard/IssuesTable.vue
@@ -21,19 +21,32 @@
                 <h2 class="mx-auto section-title">Issues</h2>
             </v-col>
         </v-row>
+        <v-row class="d-flex mb-4 justify-space-between">
+            <v-btn
+                elevation="0"
+                class="my-3 secondary-button"
+                color="white"
+                width="150px"
+                @click="deleteItem(undefined)"
+                :disabled="selectedIssues.length === 0"
+                data-cy="dismiss-selected"
+            >
+                Dismiss selected
+            </v-btn>
+            <v-btn
+                elevation="0"
+                class="my-3 secondary-button"
+                data-cy="view-grafana-dashboard"
+                link="true"
+                :href="grafanaDashboardUrl"
+                width="250px"
+                target="_blank"
+            >
+                View Grafana Dashboard
+            </v-btn>
+        </v-row>
         <v-row v-if="!loading && issues !== undefined">
-            <v-layout child-flex column>
-                <v-btn
-                    elevation="0"
-                    class="my-3 secondary-button"
-                    color="white"
-                    width="150px"
-                    @click="deleteItem(undefined)"
-                    :disabled="selectedIssues.length === 0"
-                    data-cy="dismiss-selected"
-                >
-                    Dismiss selected
-                </v-btn>
+            <v-layout column>
                 <v-card>
                     <v-card-title class="d-none">
                         <v-spacer></v-spacer>
@@ -182,6 +195,7 @@ export default class IssuesTable extends Vue {
         { text: "Time", value: "execution_time" },
         { text: "Actions", value: "actions", width: "250px" },
     ];
+    grafanaDashboardUrl = process.env.VUE_APP_GRAFANA_DASHBOARD_URL;
 
     async created(): Promise<void> {
         this.getExecutionIssues();


### PR DESCRIPTION
### Description

Fixes #AC 914 - Added a link on System dashboard to open up Grafana.

A few sentences describing the changes proposed in this pull request.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New unit tests added to cover the changes.
- [ ] New e2e tests added to cover the changes. (If it has been decided these will not be added with the PR, a seperate ticket **must** be created and linked in the ticket below before merge)
- [ ] All tests passed locally.
