### PR TITLE
AC-1102 : Partial Fail UI handling

### DIFF
--- a/src/components/AdminPayloadDashboard/ExecutionTree.vue
+++ b/src/components/AdminPayloadDashboard/ExecutionTree.vue
@@ -214,7 +214,9 @@ export default class ExecutionTree extends Vue {
     background-color: orange;
 
     &.Failed,
-    &.failed {
+    &.failed,
+    &.PartialFail,
+    &.partialFail {
         background-color: red;
     }
 

--- a/src/components/AdminPayloadDashboard/ModelDetailsSection.vue
+++ b/src/components/AdminPayloadDashboard/ModelDetailsSection.vue
@@ -23,7 +23,7 @@
             :text-color="selectedNode.status | statusChipText"
             data-cy="selected-node-status"
         >
-            <strong>{{ selectedNode.status }}</strong>
+            <strong>{{ selectedNode.status | statusDisplayText }}</strong>
         </v-chip>
         <p data-cy="selected-node-started">
             <strong class="mr-sm-7 mr-lg-0">Execution started: </strong>
@@ -113,6 +113,8 @@ import mimeTypes from "mime-types";
 
                 case "Failed":
                 case "failed":
+                case "PartialFail":
+                case "partialfail":
                     return "red lighten-4";
 
                 default:
@@ -127,10 +129,22 @@ import mimeTypes from "mime-types";
 
                 case "Failed":
                 case "failed":
+                case "PartialFail":
+                case "partialfail":
                     return "red darken-3";
 
                 default:
                     return "orange darken-3";
+            }
+        },
+        statusDisplayText: (status: string) => {
+            switch (status) {
+                case "PartialFail":
+                case "partialfail":
+                    return "Partial Fail";
+
+                default:
+                    return status;
             }
         },
     },


### PR DESCRIPTION
### Description

Fixes #AC-1102 : Show Partial Fail with a red node, and display the text correctly in red and as "Partial Fail"

A few sentences describing the changes proposed in this pull request.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New unit tests added to cover the changes.
- [ ] New e2e tests added to cover the changes. (If it has been decided these will not be added with the PR, a seperate ticket **must** be created and linked in the ticket below before merge)
- [ ] All tests passed locally.
