### PR TITLE
hide application repository link from side menu

### DIFF
--- a/src/components/AppSidebar.vue
+++ b/src/components/AppSidebar.vue
@@ -89,7 +89,8 @@ export default class AppSidebar extends Vue {
             datacy: "clinician-button",
             ...this.getRouteData("ClinicalReview"),
         },
-        this.getDefaultRoute(),
+        // Disable default route(Application Repository) until app store is ready
+        // this.getDefaultRoute(),
         {
             title: "Export Destinations",
             icon: "mdi-application-export",


### PR DESCRIPTION
### Description
Removes the Application Repository link from the main menu


### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New unit tests added to cover the changes.
- [ ] New e2e tests added to cover the changes. (If it has been decided these will not be added with the PR, a seperate ticket **must** be created and linked in the ticket below before merge)
- [ ] All tests passed locally.
